### PR TITLE
feat: realtime websocket change notifications via Change Tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -407,8 +408,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -456,6 +459,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -677,10 +689,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -704,12 +735,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -875,6 +922,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1295,6 +1352,7 @@ dependencies = [
  "clap",
  "claw",
  "csv",
+ "futures-util",
  "http",
  "jsonwebtoken",
  "reqwest",
@@ -2178,6 +2236,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2539,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2751,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,6 +2814,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ path = "src/main.rs"
 claw = { git = "https://github.com/copycatdb/claw.git", branch = "main", features = ["arrow"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
-axum = { version = "0.8", features = ["json"] }
+axum = { version = "0.8", features = ["json", "ws"] }
+futures-util = "0.3"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,14 @@ pub struct Args {
     /// Subcommand
     #[command(subcommand)]
     pub subcmd: Option<SubCommand>,
+
+    /// Enable realtime WebSocket endpoint
+    #[arg(long, env = "LAZYPAW_REALTIME", default_value = "false")]
+    pub realtime: bool,
+
+    /// Realtime poll interval in milliseconds
+    #[arg(long, env = "LAZYPAW_REALTIME_POLL_MS", default_value = "200")]
+    pub realtime_poll_ms: u64,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -192,6 +200,8 @@ pub struct AppConfig {
     pub sp_tenant_id: Option<String>,
     pub sp_client_id: Option<String>,
     pub sp_client_secret: Option<String>,
+    pub realtime: bool,
+    pub realtime_poll_ms: u64,
 }
 
 impl AppConfig {
@@ -327,6 +337,8 @@ impl AppConfig {
             sp_tenant_id: args.sp_tenant_id,
             sp_client_id: args.sp_client_id,
             sp_client_secret: args.sp_client_secret,
+            realtime: args.realtime,
+            realtime_poll_ms: args.realtime_poll_ms,
         }
     }
 }

--- a/src/realtime.rs
+++ b/src/realtime.rs
@@ -1,0 +1,545 @@
+#![allow(dead_code)]
+//! Realtime change notification engine using SQL Server Change Tracking.
+
+use crate::config::AppConfig;
+use crate::filters::{self, Filter, FilterOp, FilterValue};
+use crate::pool::Pool;
+use crate::query::escape_ident;
+use crate::schema::SchemaCache;
+use crate::types;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ChangeOp {
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChangeEvent {
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub id: String,
+    pub table: String,
+    pub record: serde_json::Map<String, JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ClientMessage {
+    Subscribe {
+        id: String,
+        table: String,
+        #[serde(default)]
+        filter: Option<String>,
+        #[serde(default)]
+        events: Option<Vec<String>>,
+    },
+    Unsubscribe {
+        id: String,
+    },
+    Ping,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(untagged)]
+pub enum ServerMessage {
+    Subscribed {
+        #[serde(rename = "type")]
+        type_: &'static str,
+        id: String,
+        table: String,
+    },
+    Unsubscribed {
+        #[serde(rename = "type")]
+        type_: &'static str,
+        id: String,
+    },
+    Error {
+        #[serde(rename = "type")]
+        type_: &'static str,
+        message: String,
+    },
+    Pong {
+        #[serde(rename = "type")]
+        type_: &'static str,
+    },
+    Change {
+        #[serde(rename = "type")]
+        type_: String,
+        id: String,
+        table: String,
+        record: serde_json::Map<String, JsonValue>,
+    },
+}
+
+struct Subscription {
+    id: String,
+    table_key: String,
+    client_tx: mpsc::Sender<ServerMessage>,
+    filter: Option<Vec<Filter>>,
+    events: HashSet<ChangeOp>,
+}
+
+pub struct RealtimeEngine {
+    table_subs: RwLock<HashMap<String, Vec<Uuid>>>,
+    all_subs: RwLock<HashMap<Uuid, Subscription>>,
+    client_subs: RwLock<HashMap<Uuid, Vec<Uuid>>>,
+    last_version: AtomicI64,
+    pool: Arc<Pool>,
+    schema: Arc<RwLock<SchemaCache>>,
+    config: AppConfig,
+}
+
+impl RealtimeEngine {
+    pub fn new(pool: Arc<Pool>, schema: Arc<RwLock<SchemaCache>>, config: AppConfig) -> Arc<Self> {
+        Arc::new(Self {
+            table_subs: RwLock::new(HashMap::new()),
+            all_subs: RwLock::new(HashMap::new()),
+            client_subs: RwLock::new(HashMap::new()),
+            last_version: AtomicI64::new(-1),
+            pool,
+            schema,
+            config,
+        })
+    }
+
+    pub async fn subscribe(
+        &self,
+        client_id: Uuid,
+        sub_id: String,
+        table: &str,
+        filter_str: Option<&str>,
+        events: Option<Vec<String>>,
+        tx: mpsc::Sender<ServerMessage>,
+    ) -> Result<String, String> {
+        let schema_cache = self.schema.read().await;
+
+        let (schema_name, table_name) = if table.contains('.') {
+            let parts: Vec<&str> = table.splitn(2, '.').collect();
+            (parts[0].to_string(), parts[1].to_string())
+        } else {
+            (self.config.default_schema.clone(), table.to_string())
+        };
+
+        let table_key = format!("{}.{}", schema_name, table_name);
+
+        let table_info = schema_cache
+            .get_table(&schema_name, &table_name)
+            .ok_or_else(|| format!("Table not found: {}", table_key))?;
+
+        if !table_info.change_tracking_enabled {
+            return Err(format!("Change tracking not enabled on {}", table_key));
+        }
+
+        // Parse filters
+        let parsed_filters = if let Some(f) = filter_str {
+            let mut fv = Vec::new();
+            for part in f.split('&') {
+                if let Some((key, val)) = part.split_once('=') {
+                    match filters::parse_filter(key, val) {
+                        Ok(filter) => fv.push(filter),
+                        Err(e) => return Err(format!("Invalid filter: {}", e)),
+                    }
+                }
+            }
+            Some(fv)
+        } else {
+            None
+        };
+
+        let event_set: HashSet<ChangeOp> = if let Some(evts) = events {
+            evts.iter()
+                .map(|e| match e.to_uppercase().as_str() {
+                    "INSERT" => ChangeOp::Insert,
+                    "UPDATE" => ChangeOp::Update,
+                    "DELETE" => ChangeOp::Delete,
+                    _ => ChangeOp::Insert,
+                })
+                .collect()
+        } else {
+            [ChangeOp::Insert, ChangeOp::Update, ChangeOp::Delete]
+                .into_iter()
+                .collect()
+        };
+
+        let sub_uuid = Uuid::new_v4();
+        let sub = Subscription {
+            id: sub_id,
+            table_key: table_key.clone(),
+            client_tx: tx,
+            filter: parsed_filters,
+            events: event_set,
+        };
+
+        self.all_subs.write().await.insert(sub_uuid, sub);
+        self.table_subs
+            .write()
+            .await
+            .entry(table_key.clone())
+            .or_default()
+            .push(sub_uuid);
+        self.client_subs
+            .write()
+            .await
+            .entry(client_id)
+            .or_default()
+            .push(sub_uuid);
+
+        Ok(table_key)
+    }
+
+    pub async fn unsubscribe(&self, client_id: Uuid, sub_id: &str) {
+        let client_sub_uuids = self
+            .client_subs
+            .read()
+            .await
+            .get(&client_id)
+            .cloned()
+            .unwrap_or_default();
+        let mut to_remove = None;
+        for uuid in &client_sub_uuids {
+            if let Some(sub) = self.all_subs.read().await.get(uuid) {
+                if sub.id == sub_id {
+                    to_remove = Some((*uuid, sub.table_key.clone()));
+                    break;
+                }
+            }
+        }
+        if let Some((uuid, table_key)) = to_remove {
+            self.all_subs.write().await.remove(&uuid);
+            if let Some(subs) = self.table_subs.write().await.get_mut(&table_key) {
+                subs.retain(|u| *u != uuid);
+            }
+            if let Some(subs) = self.client_subs.write().await.get_mut(&client_id) {
+                subs.retain(|u| *u != uuid);
+            }
+        }
+    }
+
+    pub async fn remove_client(&self, client_id: Uuid) {
+        let sub_uuids = self
+            .client_subs
+            .write()
+            .await
+            .remove(&client_id)
+            .unwrap_or_default();
+        for uuid in sub_uuids {
+            if let Some(sub) = self.all_subs.write().await.remove(&uuid) {
+                if let Some(subs) = self.table_subs.write().await.get_mut(&sub.table_key) {
+                    subs.retain(|u| *u != uuid);
+                }
+            }
+        }
+    }
+
+    pub async fn init_version(&self) -> Result<(), String> {
+        let mut conn = self.pool.get().await.map_err(|e| e.to_string())?;
+        let client = conn.client();
+        let stream = claw::Query::new("SELECT CHANGE_TRACKING_CURRENT_VERSION()")
+            .query(client)
+            .await
+            .map_err(|e| e.to_string())?;
+        let rows = stream
+            .into_first_result()
+            .await
+            .map_err(|e| e.to_string())?;
+        if let Some(row) = rows.first() {
+            let json = types::row_to_json(row);
+            if let Some((_, val)) = json.into_iter().next() {
+                match val {
+                    JsonValue::Number(n) => {
+                        if let Some(v) = n.as_i64() {
+                            self.last_version.store(v, Ordering::SeqCst);
+                        }
+                    }
+                    JsonValue::Null => {
+                        self.last_version.store(0, Ordering::SeqCst);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn poll_loop(self: Arc<Self>, poll_ms: u64) {
+        loop {
+            if let Err(e) = self.poll_once().await {
+                tracing::error!("Realtime poll error: {}", e);
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(poll_ms)).await;
+        }
+    }
+
+    async fn poll_once(&self) -> Result<(), String> {
+        let active_tables: Vec<String> = {
+            let table_subs = self.table_subs.read().await;
+            table_subs
+                .iter()
+                .filter(|(_, subs)| !subs.is_empty())
+                .map(|(k, _)| k.clone())
+                .collect()
+        };
+
+        if active_tables.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.pool.get().await.map_err(|e| e.to_string())?;
+        let client = conn.client();
+
+        // Get current version
+        let stream = claw::Query::new("SELECT CHANGE_TRACKING_CURRENT_VERSION()")
+            .query(client)
+            .await
+            .map_err(|e| e.to_string())?;
+        let version_rows = stream
+            .into_first_result()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let current_version = if let Some(row) = version_rows.first() {
+            let json = types::row_to_json(row);
+            if let Some((_, JsonValue::Number(n))) = json.into_iter().next() {
+                n.as_i64().unwrap_or(0)
+            } else {
+                return Ok(());
+            }
+        } else {
+            return Ok(());
+        };
+
+        let last = self.last_version.load(Ordering::SeqCst);
+        if current_version <= last {
+            return Ok(());
+        }
+
+        let schema_cache = self.schema.read().await;
+
+        for table_key in &active_tables {
+            let parts: Vec<&str> = table_key.splitn(2, '.').collect();
+            if parts.len() != 2 {
+                continue;
+            }
+            let (schema_name, table_name) = (parts[0], parts[1]);
+
+            let table_info = match schema_cache.get_table(schema_name, table_name) {
+                Some(t) => t,
+                None => continue,
+            };
+
+            if table_info.primary_key.is_empty() {
+                continue;
+            }
+
+            let pk_join = table_info
+                .primary_key
+                .iter()
+                .map(|pk| format!("t.[{}] = ct.[{}]", escape_ident(pk), escape_ident(pk)))
+                .collect::<Vec<_>>()
+                .join(" AND ");
+
+            let all_cols = table_info
+                .columns
+                .iter()
+                .map(|c| format!("t.[{}]", escape_ident(&c.name)))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let ct_pk_cols = table_info
+                .primary_key
+                .iter()
+                .map(|pk| format!("ct.[{}] AS [__ct_{}]", escape_ident(pk), escape_ident(pk)))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let sql = format!(
+                "SELECT ct.SYS_CHANGE_OPERATION, ct.SYS_CHANGE_VERSION, {}, {} \
+                 FROM CHANGETABLE(CHANGES [{}].[{}], @P1) AS ct \
+                 LEFT JOIN [{}].[{}] t ON {}",
+                ct_pk_cols,
+                all_cols,
+                escape_ident(schema_name),
+                escape_ident(table_name),
+                escape_ident(schema_name),
+                escape_ident(table_name),
+                pk_join
+            );
+
+            let mut query = claw::Query::new(&sql);
+            query.bind(last);
+            let stream = match query.query(client).await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("CT query failed for {}: {}", table_key, e);
+                    continue;
+                }
+            };
+            let rows = match stream.into_first_result().await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("CT result failed for {}: {}", table_key, e);
+                    continue;
+                }
+            };
+
+            for row in &rows {
+                let row_json = types::row_to_json(row);
+
+                // Get operation
+                let op = match row_json.get("SYS_CHANGE_OPERATION") {
+                    Some(JsonValue::String(s)) => match s.as_str() {
+                        "I" => ChangeOp::Insert,
+                        "U" => ChangeOp::Update,
+                        "D" => ChangeOp::Delete,
+                        _ => continue,
+                    },
+                    _ => continue,
+                };
+
+                // Build record (exclude CT internal columns)
+                let mut record = serde_json::Map::new();
+                if op == ChangeOp::Delete {
+                    // For DELETE, use ct PK columns
+                    for (k, v) in &row_json {
+                        if let Some(pk_name) = k.strip_prefix("__ct_") {
+                            record.insert(pk_name.to_string(), v.clone());
+                        }
+                    }
+                } else {
+                    for (k, v) in &row_json {
+                        if !k.starts_with("SYS_CHANGE_") && !k.starts_with("__ct_") {
+                            record.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+
+                // Fan out to subscriptions
+                let sub_uuids = self
+                    .table_subs
+                    .read()
+                    .await
+                    .get(table_key)
+                    .cloned()
+                    .unwrap_or_default();
+
+                let all_subs = self.all_subs.read().await;
+                for sub_uuid in &sub_uuids {
+                    if let Some(sub) = all_subs.get(sub_uuid) {
+                        if !sub.events.contains(&op) {
+                            continue;
+                        }
+
+                        if let Some(ref filter_list) = sub.filter {
+                            let mut matches = true;
+                            for filter in filter_list {
+                                if let Some(val) = record.get(&filter.column) {
+                                    if !filter_matches(filter, val) {
+                                        matches = false;
+                                        break;
+                                    }
+                                }
+                            }
+                            if !matches {
+                                continue;
+                            }
+                        }
+
+                        let op_str = match op {
+                            ChangeOp::Insert => "INSERT",
+                            ChangeOp::Update => "UPDATE",
+                            ChangeOp::Delete => "DELETE",
+                        };
+
+                        let msg = ServerMessage::Change {
+                            type_: op_str.to_string(),
+                            id: sub.id.clone(),
+                            table: table_key.clone(),
+                            record: record.clone(),
+                        };
+
+                        let _ = sub.client_tx.try_send(msg);
+                    }
+                }
+            }
+        }
+
+        self.last_version.store(current_version, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn filter_matches(filter: &Filter, value: &JsonValue) -> bool {
+    let val_str = match value {
+        JsonValue::String(s) => s.clone(),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Null => "null".to_string(),
+        other => other.to_string(),
+    };
+
+    let result = match &filter.operator {
+        FilterOp::Eq => match &filter.value {
+            FilterValue::Single(expected) => val_str == *expected,
+            _ => true,
+        },
+        FilterOp::Neq => match &filter.value {
+            FilterValue::Single(expected) => val_str != *expected,
+            _ => true,
+        },
+        FilterOp::In => match &filter.value {
+            FilterValue::List(items) => items.iter().any(|i| *i == val_str),
+            _ => true,
+        },
+        FilterOp::Is => match &filter.value {
+            FilterValue::Single(expected) => match expected.to_lowercase().as_str() {
+                "null" => value.is_null(),
+                "true" => value == &JsonValue::Bool(true),
+                "false" => value == &JsonValue::Bool(false),
+                _ => true,
+            },
+            _ => true,
+        },
+        // For comparison ops, try numeric comparison
+        FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte => {
+            match &filter.value {
+                FilterValue::Single(expected) => {
+                    if let (Ok(a), Ok(b)) = (val_str.parse::<f64>(), expected.parse::<f64>()) {
+                        match &filter.operator {
+                            FilterOp::Gt => a > b,
+                            FilterOp::Gte => a >= b,
+                            FilterOp::Lt => a < b,
+                            FilterOp::Lte => a <= b,
+                            _ => true,
+                        }
+                    } else {
+                        // String comparison fallback
+                        match &filter.operator {
+                            FilterOp::Gt => val_str > *expected,
+                            FilterOp::Gte => val_str >= *expected,
+                            FilterOp::Lt => val_str < *expected,
+                            FilterOp::Lte => val_str <= *expected,
+                            _ => true,
+                        }
+                    }
+                }
+                _ => true,
+            }
+        }
+        _ => true, // Like, Ilike, Fts — pass through
+    };
+
+    if filter.negated {
+        !result
+    } else {
+        result
+    }
+}

--- a/src/realtime_ws.rs
+++ b/src/realtime_ws.rs
@@ -1,0 +1,128 @@
+#![allow(dead_code)]
+//! WebSocket handler for realtime change notifications.
+
+use crate::auth;
+use crate::config::AppConfig;
+use crate::realtime::{ClientMessage, RealtimeEngine, ServerMessage};
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::response::Response;
+use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+/// Combined state for the websocket handler.
+#[derive(Clone)]
+pub struct WsState {
+    pub engine: Arc<RealtimeEngine>,
+    pub config: AppConfig,
+}
+
+#[derive(serde::Deserialize)]
+pub struct WsQuery {
+    #[serde(default)]
+    token: Option<String>,
+}
+
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<WsState>,
+    Query(query): Query<WsQuery>,
+) -> Response {
+    let claims = if let Some(ref token) = query.token {
+        let header = format!("Bearer {}", token);
+        match auth::authenticate(Some(&header), &state.config) {
+            Ok(c) => c,
+            Err(_) => None,
+        }
+    } else {
+        None
+    };
+
+    ws.on_upgrade(move |socket| handle_socket(socket, state.engine, claims))
+}
+
+async fn handle_socket(
+    socket: WebSocket,
+    engine: Arc<RealtimeEngine>,
+    _claims: Option<auth::Claims>,
+) {
+    let client_id = Uuid::new_v4();
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    let (tx, mut rx) = mpsc::channel::<ServerMessage>(256);
+
+    // Forward engine messages to websocket
+    let send_task = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            if let Ok(json) = serde_json::to_string(&msg) {
+                if ws_tx.send(Message::Text(json.into())).await.is_err() {
+                    break;
+                }
+            }
+        }
+    });
+
+    // Read client messages
+    while let Some(Ok(msg)) = ws_rx.next().await {
+        match msg {
+            Message::Text(text) => {
+                if let Ok(client_msg) = serde_json::from_str::<ClientMessage>(&text) {
+                    match client_msg {
+                        ClientMessage::Subscribe {
+                            id,
+                            table,
+                            filter,
+                            events,
+                        } => match engine
+                            .subscribe(
+                                client_id,
+                                id.clone(),
+                                &table,
+                                filter.as_deref(),
+                                events,
+                                tx.clone(),
+                            )
+                            .await
+                        {
+                            Ok(table_key) => {
+                                let _ = tx
+                                    .send(ServerMessage::Subscribed {
+                                        type_: "subscribed",
+                                        id,
+                                        table: table_key,
+                                    })
+                                    .await;
+                            }
+                            Err(e) => {
+                                let _ = tx
+                                    .send(ServerMessage::Error {
+                                        type_: "error",
+                                        message: e,
+                                    })
+                                    .await;
+                            }
+                        },
+                        ClientMessage::Unsubscribe { id } => {
+                            engine.unsubscribe(client_id, &id).await;
+                            let _ = tx
+                                .send(ServerMessage::Unsubscribed {
+                                    type_: "unsubscribed",
+                                    id,
+                                })
+                                .await;
+                        }
+                        ClientMessage::Ping => {
+                            let _ = tx.send(ServerMessage::Pong { type_: "pong" }).await;
+                        }
+                    }
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+
+    engine.remove_client(client_id).await;
+    send_task.abort();
+}


### PR DESCRIPTION
Adds `/realtime` WebSocket endpoint that pushes SQL Server table changes to connected clients using Change Tracking.

- New `--realtime` flag to enable the feature
- `--realtime-poll-ms` to configure poll interval (default 200ms)
- Schema introspection now detects Change Tracking enabled tables
- Clients subscribe/unsubscribe to table changes with optional filters and event type filtering
- Supports INSERT, UPDATE, DELETE notifications

Closes #13