### PR TITLE
docs: document implemented features (closes #32, #33, #34, #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+## Features Already Implemented
+
+- **Upsert (MERGE)**: `Prefer: resolution=merge-duplicates` header on POST triggers T-SQL MERGE (#32)
+- **RPC (Stored Procedures)**: `POST /rpc/:proc_name` with JSON body params (#33)
+- **Exact Count**: `Prefer: count=exact` header returns total count in Content-Range (#34)
+- **Single Object Response**: `Accept: application/vnd.pgrst.object+json` returns single object or 406 (#35)


### PR DESCRIPTION
All four features from issues #32-35 are already implemented on main:

- **#32 Upsert/MERGE**: `Prefer: resolution=merge-duplicates` in POST triggers MERGE via `build_upsert`
- **#33 RPC**: `POST /rpc/:proc_name` handler with JSON param binding
- **#34 Exact Count**: `Prefer: count=exact` runs count query, sets Content-Range
- **#35 Single Object**: `Accept: application/vnd.pgrst.object+json` returns 406 on !=1 rows

This PR adds a CHANGELOG entry documenting these features.

Closes #32, closes #33, closes #34, closes #35