### PR TITLE
feat: polish — timestamp normalization, error sanitization, hide default schema

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -10,8 +10,10 @@ pub fn generate_openapi(schema: &SchemaCache, config: &AppConfig) -> Value {
     let mut paths = Map::new();
     let mut schemas = Map::new();
 
+    let multi_schema = schema.has_multiple_schemas();
+
     for ((schema_name, _table_name), table) in &schema.tables {
-        let path = if schema_name.eq_ignore_ascii_case(&config.default_schema) {
+        let path = if !multi_schema || schema_name.eq_ignore_ascii_case(&config.default_schema) {
             format!("/{}", table.name)
         } else {
             format!("/{}/{}", schema_name, table.name)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -155,6 +155,14 @@ impl SchemaCache {
 
         None
     }
+    /// Check if all tables belong to a single schema.
+    pub fn has_multiple_schemas(&self) -> bool {
+        let mut schemas = std::collections::HashSet::new();
+        for (schema, _) in self.tables.keys() {
+            schemas.insert(schema.to_lowercase());
+        }
+        schemas.len() > 1
+    }
 }
 
 /// Info about how to embed a related table.


### PR DESCRIPTION
Implements #38, #39, #40 in one PR.

### Timestamp Normalization (#38)
- DateTime/DateTime2: 3 decimal places + Z suffix (e.g. `2026-02-16T08:05:00.527Z`)
- DateTimeOffset: 3 decimal places, Z for UTC offsets

### Error Sanitization (#39)
- Return generic error messages to clients ("Bad request", "Not found", etc.)
- Log full SQL Server errors server-side at error! level
- No more table names or query text leaked in responses

### Hide Default Schema (#40)
- Omit schema prefix from OpenAPI routes when all tables are in one schema
- `/games` instead of `/dbo/games` when only dbo exists

Closes #38, closes #39, closes #40